### PR TITLE
Further improvements

### DIFF
--- a/Software/EPROM_EMU_NG_2.0rc10.py
+++ b/Software/EPROM_EMU_NG_2.0rc10.py
@@ -298,7 +298,9 @@ else:
 	default_location = (100,100)
 	# Retrieve last saved window position or use the default
 	last_position = sg.user_settings_get_entry('window_location', default_location)
-
+	# Validate position
+	if last_position is None or not isinstance(last_position, tuple) or len(last_position) != 2:
+		last_position = default_location
 	window = sg.Window('EPROM EMU NG Uploader '+version, layout, location=last_position)
 	gui = True
 

--- a/Software/EPROM_EMU_NG_2.0rc10.py
+++ b/Software/EPROM_EMU_NG_2.0rc10.py
@@ -232,7 +232,7 @@ def ParseIntelLine(line):
 # -----------------------------------------------------------------------
 
 def get_com_ports():
-    return [p.device for p in comports()]
+	return [p.device for p in comports()]
 
 # -----------------------------------------------------------------------
 
@@ -245,7 +245,7 @@ sg.theme('DarkBlue3')   # Add a touch of color
 
 layout = [
 	[sg.Text('EPROM Emulator Uploader', font=("Helvetica", 16), justification='center')],
-    [sg.Column( [
+	[sg.Column( [
 	[sg.Frame(
 		"EPROM Settings",
 		[[sg.Text('EPROM Type:', size=(40, 1)), sg.Combo(
@@ -271,8 +271,8 @@ layout = [
 	)],
 	[sg.Checkbox('Show Data Map', sg.user_settings_get_entry('map', True), key='map')],
 	[sg.Button('Submit'), sg.Button('Cancel')]
-    ], pad=(0,0), scrollable=False
-    )]
+	], pad=(0,0), scrollable=False
+	)]
 ]
 
 if len(sys.argv) >= 2:
@@ -377,11 +377,11 @@ elif mem == "27512":
 	max_size = 65536
 
 try:
-        ser = serial.Serial(port=port,baudrate=115200,timeout=0.5,writeTimeout=0)
+		ser = serial.Serial(port=port,baudrate=115200,timeout=0.5,writeTimeout=0)
 		#ser = serial.Serial(port=port,baudrate=1000000,timeout=0.5,writeTimeout=0)
 except:
-        print("Failed to open port, verify port name")
-        exit()
+		print("Failed to open port, verify port name")
+		exit()
 
 # ------------------------------------------------------------------------
 buff64k = [-1]*65536

--- a/Software/EPROM_EMU_NG_2.0rc10.py
+++ b/Software/EPROM_EMU_NG_2.0rc10.py
@@ -417,10 +417,9 @@ else:	# process hex file
 	with open(file) as fp:
 		while True:
 			line = fp.readline()
-			if len(line) > 0:
-				if ParseIntelLine(line):
-					break
-			else:
+			if not line:
+				break
+			if ParseIntelLine(line):
 				break
 		if Errors == 0:
 			print("done (hex)")

--- a/Software/EPROM_EMU_NG_2.0rc10.py
+++ b/Software/EPROM_EMU_NG_2.0rc10.py
@@ -469,25 +469,25 @@ try:
 	
 	print("\n<- attempting to get sync")
 
-	data_tx = (":EMUOFF\r\n").encode()
+	data_tx = b":EMUOFF\r\n"
 	ser.write(data_tx)
 	response = ser.readline()
 
-	if "HW: " in response.decode():	# Emulator will respond with version number like "HW: v1.0"
+	if b"HW: " in response:	# Emulator will respond with version number like "HW: v1.0"
 		print(response.decode())
-	elif ".." in response.decode():
+	elif b".." in response:
 		print("Waiting for autoupload to finish...")
-		while ".." in ser.readline().decode():
+		while b".." in ser.readline():
 			print(".", end=' ', flush=True)	
 		
 		print("")
 		time.sleep(2)
 		ser.flushInput() # ignore anything waiting in the input buffer.
 
-		data_tx = (":EMUOFF\r\n").encode()
+		data_tx = b":EMUOFF\r\n"
 		ser.write(data_tx)
 		response = ser.readline()
-		if "HW: " in response.decode():
+		if b"HW: " in response:
 			print(response.decode())
 		else:
 			print("Failed to connect after autoload - exiting")
@@ -495,12 +495,12 @@ try:
 			exit()
 	else:
 		# try to see if emulator running old FW is connected
-		data_tx = (":dml\r\n").encode()
+		data_tx = b":dml\r\n"
 		ser.write(data_tx)
 		response = ser.readline()
 		print("\n")
-		if "HW: " in response.decode():
-			print(response.decode())
+		if b"HW: " in response:
+			print(response.decode(errors="ignore"))
 			print("-"*80)
 			print("    !!! Looks like you are using an old version of firmware on your emulator !!!")
 			print("        Please upgrade using Arduino platform and compatible .ino file")
@@ -518,13 +518,13 @@ try:
 	#
 	if spi == "y":
 		print('<- Setting "Save to SPI EEPROM" option to enable')
-		data_tx = (":iniSPI1\r\n").encode()
+		data_tx = b":iniSPI1\r\n"
 		ser.write(data_tx)
 		response = ser.readline()
 		print(response.decode())
 	if spi == "n":
 		print('<- Setting "Save to SPI EEPROM" option to disable')
-		data_tx = (":iniSPI0\r\n").encode()
+		data_tx = b":iniSPI0\r\n"
 		ser.write(data_tx)
 		response = ser.readline()
 		print(response.decode())
@@ -534,13 +534,13 @@ try:
 	#
 	if auto == "y":
 		print('<- Setting "Auto load from SPI EEPROM" option to enable')
-		data_tx = (":iniAuto1\r\n").encode()
+		data_tx = b":iniAuto1\r\n"
 		ser.write(data_tx)
 		response = ser.readline()
 		print(response.decode())
 	if auto == "n":
 		print('<- Setting "Auto load from SPI EEPROM" option to disable')
-		data_tx = (":iniAuto0\r\n").encode()
+		data_tx = b":iniAuto0\r\n"
 		ser.write(data_tx)
 		response = ser.readline()
 		print(response.decode())
@@ -553,9 +553,9 @@ try:
 		
 		# request byte frame processing
 		if spi == "y":
-			data_tx = (":SBN\r\n").encode()
+			data_tx = b":SBN\r\n"
 		else:
-			data_tx = (":DIR\r\n").encode()
+			data_tx = b":DIR\r\n"
 		
 		ser.write(data_tx)
 		# Wait for ACK
@@ -573,7 +573,7 @@ try:
 				buff64k[x] = 0xff
 		
 		# send to emulator
-		ser.write(buff64k[StartAddr:StartAddr+FrameSize])
+		ser.write(bytes(buff64k[StartAddr:StartAddr+FrameSize]))
 		response = ser.readline()
 		
 		print("0x%0.4X"%StartAddr,response.decode().strip(), end='\r', flush=True)
@@ -591,7 +591,7 @@ try:
 	print("<- Enable Emulation")
 	
 	# enable emulation
-	data_tx = (":EMUON\r\n").encode()
+	data_tx = b":EMUON\r\n"
 	ser.write(data_tx)
 
 	response = ser.readline()

--- a/Software/EPROM_EMU_NG_2.0rc10.py
+++ b/Software/EPROM_EMU_NG_2.0rc10.py
@@ -405,6 +405,11 @@ if isbin:	# process bin
 	binfile = open(file,"rb").read()
 	file_size = len(binfile)
 
+	# Validate file size against maximum buffer size
+	if startaddr + file_size > len(buff64k):
+		print("Error: File size exceeds buffer capacity.")
+		sys.exit(1)
+
 	# load the binary file into the buffer at start location
 	for x in range (0,file_size):
 		buff64k[x+startaddr] = binfile[x]


### PR DESCRIPTION
I used this patch set to get the eprom emulator working
when ssh-ing into my Raspberry Pi from my Macbook which
was failing before due to some UTF-8 character conversion
that didn't seem to bother Python when ssh-ing in from
a Ubuntu workstation.

- **Fix indentation**
- **Fallback for saved window position**
- **Switch communication to be all in binary**
- **Make output of the script more compact**
- **Simplify Intel line parsing**
- **Verify that file loaded is not larger than buffer**
